### PR TITLE
Remove duplicated ros-kinectic-hector-mapping from install guide. Als…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can install Ros(Kinetic), Gazebo 8, necessary packages by the following comm
     $ wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -     
     $ sudo apt-get update   
     $ sudo apt-get install -y cmake g++ protobuf-compiler pavucontrol libignition-math3 libsdformat5 libignition-math3-dev libignition-msgs0-dev gazebo8-plugin-base libgazebo8 libgazebo8-dev ros-kinetic-desktop  ros-kinetic-ros-control ros-kinetic-ros-controllers ros-kinetic-image-view2 ros-kinetic-rqt ros-kinetic-rqt-common-plugins ros-kinetic-joy ros-kinetic-teleop-twist-keyboard ros-kinetic-message-to-tf ros-kinetic-tf2-geometry-msgs ros-kinetic-audio-common ros-kinetic-costmap-2d ros-kinetic-image-transport ros-kinetic-image-transport-plugins ros-kinetic-hector-mapping ros-kinetic-hector-geotiff 
-    $ sudo apt-get install ros-kinetic-hector-pose-estimation ros-kinetic-hector-sensors-description ros-kinetic-controller-manager ros-kinetic-gmapping ros-kinetic-move-base ros-kinetic-hector-mapping ros-kinetic-gazebo8* 
+    $ sudo apt-get install -y ros-kinetic-hector-pose-estimation ros-kinetic-hector-sensors-description ros-kinetic-controller-manager ros-kinetic-gmapping ros-kinetic-move-base ros-kinetic-gazebo8* 
 
 
 ##  Network Setup


### PR DESCRIPTION
…o add `-y` on second install for consistency.